### PR TITLE
persist user after login to fix error from profile click

### DIFF
--- a/frontend/src/contexts/LoginContext.jsx
+++ b/frontend/src/contexts/LoginContext.jsx
@@ -19,10 +19,11 @@ function LoginProvider({ children }) {
     setIsLoggedIn(storedLoginState);
   }, []);
 
-  const login = (token) => {
+  const login = (token, userData) => {
     setIsLoggedIn(true);
     localStorage.setItem('isLoggedIn', true);
     localStorage.setItem('token', token);
+    localStorage.setItem('userData', JSON.stringify(userData));
   };
 
   const toggleLogin = (token) => {
@@ -39,13 +40,12 @@ function LoginProvider({ children }) {
     setIsLoggedIn(false);
     localStorage.setItem('isLoggedIn', false);
     localStorage.removeItem('token');
+    localStorage.removeItem('userData');
     navigate('/');
   };
 
   return (
-    <LoginContext.Provider
-      value={{ isLoggedIn, login, toggleLogin, handleLogout }}
-    >
+    <LoginContext.Provider value={{ isLoggedIn, login, toggleLogin, handleLogout }}>
       {children}
     </LoginContext.Provider>
   );

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -1,16 +1,31 @@
 /* eslint-disable react-refresh/only-export-components */
 /* eslint-disable react/prop-types */
-import { createContext, useContext } from "react"
+import { createContext, useContext, useEffect, useState } from 'react';
 
 const UserContext = createContext();
 const useUserContext = () => useContext(UserContext);
 
-export default function UserProvider({ userData, setUserData, children }) {
-    return (
-        <UserContext.Provider value={{ userData, setUserData }}>
-            {children}
-        </UserContext.Provider>
-    )
-};
+export default function UserProvider({ children }) {
+  const [userData, setUserData] = useState(null);
 
-export { UserContext, useUserContext }
+  useEffect(() => {
+    const storedUserState = localStorage.getItem('userData');
+    if (storedUserState) {
+      try {
+        const parsedUserData = JSON.parse(storedUserState);
+        setUserData(parsedUserData);
+      } catch (error) {
+        console.error('Error parsing user data from localStorage:', error);
+        setUserData(null);
+      }
+    }
+  }, []);
+
+  return (
+    <UserContext.Provider value={{ userData, setUserData }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export { UserContext, useUserContext };

--- a/frontend/src/hooks/useLogin.jsx
+++ b/frontend/src/hooks/useLogin.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import axios from "axios";
 import { useLoginContext } from "../contexts/LoginContext";
 import { useNavigate } from "react-router-dom";
-import { useUserContext } from "../contexts/UserContext";
 
 export const useLogin = () => {
     const [form, setForm] = useState({ email: "", password: "" });
@@ -11,7 +10,6 @@ export const useLogin = () => {
     const [isLoading, setIsLoading] = useState(false);
 
     const { toggleLogin, login } = useLoginContext();
-    const { setUserData } = useUserContext();
     const navigate = useNavigate();
 
     const handleShowPassword = (e) => {
@@ -47,8 +45,7 @@ export const useLogin = () => {
             const res = await axios.post('http://localhost:3000/api/users/login', form);
             if (res.status === 200) {
                 toggleLogin();
-                setUserData(res.data.user);
-                login(res.data.token);
+                login(res.data.token, res.data.user);
                 navigate('/dashboard');
             }
         } catch (err) {


### PR DESCRIPTION
This PR adds changes to fix a bug that causes the app to crash when the user clicks on the profile after the page refresh or when the window is closed and opened again.

<img width="349" alt="Screenshot 2024-12-18 at 20 01 10" src="https://github.com/user-attachments/assets/831f2fca-fd77-4536-a445-a3d33cc8e08f" />

The solution is to persist the user after login by saving the user data in local storage and only clear this userData when logging out.



Closes: #32