### PR TITLE
setup the statistics Page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 # Contributors
 
 [@Mupa1](https://github.com/Mupa1)
+[@gurnish-singh](https://github.com/gurnish-singh)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,12 @@
     "axios": "^1.7.8",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.456.0",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "chart.js": "^4.4.7",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/frontend/src/components/NearestDueTask.jsx
+++ b/frontend/src/components/NearestDueTask.jsx
@@ -1,0 +1,21 @@
+import PropTypes from "prop-types";
+
+const NearestDueTask = ({ task }) => (
+    <div className="text-center bg-white p-4 rounded-lg shadow-md my-6">
+        <h3 className="text-xl font-semibold">Task with Nearest Due Date</h3>
+        <p className="text-lg">
+            {task ? `${task.name} (Due: ${task.dueDate})` : "No pending tasks"}
+        </p>
+    </div>
+);
+
+NearestDueTask.propTypes = {
+    task: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        status: PropTypes.oneOf(['completed', 'pending', 'in-progress']).isRequired,
+        dueDate: PropTypes.string.isRequired,
+    }).isRequired,
+};
+
+export default NearestDueTask;

--- a/frontend/src/components/PendingTasksCount.jsx
+++ b/frontend/src/components/PendingTasksCount.jsx
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types';
+
+const PendingTasksCount = ({ count }) => (
+    <div className="text-center bg-white p-4 rounded-lg shadow-md my-6">
+        <h3 className="text-xl font-semibold">Pending Tasks</h3>
+        <p className="text-3xl font-bold">{count}</p>
+    </div>
+);
+
+PendingTasksCount.propTypes = {
+    count: PropTypes.number.isRequired,
+
+};
+export default PendingTasksCount;

--- a/frontend/src/components/TaskCompletionChart.jsx
+++ b/frontend/src/components/TaskCompletionChart.jsx
@@ -1,0 +1,43 @@
+
+import { Pie } from "react-chartjs-2";
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const TaskCompletionChart = ({ completedTasks, totalTasks }) => {
+    const data = {
+        labels: [`Completed (${completedTasks})`,
+            `Pending (${totalTasks - completedTasks})`
+        ],
+        datasets: [
+            {
+                data: [completedTasks, totalTasks - completedTasks],
+                backgroundColor: ["rgba(237,191,243,0.82)", "rgba(193,32,239,0.6)"],
+                borderColor: ["rgba(237,191,243,1)", "rgba(193,32,239,1)"],
+                borderWidth: 1,
+            },
+        ],
+    };
+
+    const options = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: { position: "top" },
+        },
+    };
+
+    return (
+        <div className="w-full h-80 sm:h-96 md:h-[400px] lg:h-[500px] mx-auto my-6 p-4 bg-white rounded-lg shadow-lg">
+            <Pie data={data} options={options} />
+        </div>
+    );
+};
+import PropTypes from "prop-types";
+
+TaskCompletionChart.propTypes = {
+    completedTasks: PropTypes.number.isRequired,
+    totalTasks: PropTypes.number.isRequired,
+};
+
+export default TaskCompletionChart;

--- a/frontend/src/pages/Statistics.jsx
+++ b/frontend/src/pages/Statistics.jsx
@@ -1,7 +1,34 @@
+import TaskCompletionChart from '../components/TaskCompletionChart';
+import NearestDueTask from '../components/NearestDueTask';
+import PendingTasksCount from '../components/PendingTasksCount';
 export default function Statistics() {
+    const tasks = [
+        { id: 1, name: "Task 1", status: "completed", dueDate: "2024-12-21" },
+        { id: 2, name: "Task 2", status: "pending", dueDate: "2024-12-20" },
+        { id: 3, name: "Task 3", status: "pending", dueDate: "2024-12-22" },
+    ];
+
+    const totalTasks = tasks.length;
+    const completedTasks = tasks.filter(task => task.status === "completed").length;
+    const pendingTasks = tasks.filter(task => task.status === "pending").length;
+
+    const nearestDueTask = tasks
+        .filter(task => task.status !== "completed")
+        .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))[0];
+
     return (
-        <div>
-            Statistics
+        <div className="p-6 bg-gray-100 min-h-screen">
+            <h1 className="text-3xl font-bold text-center mb-8">Task Statistics</h1>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="w-full max-w-lg mx-auto">
+                    <TaskCompletionChart completedTasks={completedTasks} totalTasks={totalTasks}/>
+                </div>
+                <div className="flex flex-col ">
+                    <NearestDueTask task={nearestDueTask}/>
+                    <PendingTasksCount count={pendingTasks}/>
+                </div>
+            </div>
         </div>
-    )
+    );
 }


### PR DESCRIPTION
This PR introduces a responsive Pie Chart to display task completion statistics on the statistics screen. The chart now shows the number of completed and pending tasks
![image](https://github.com/user-attachments/assets/9544a9df-6a96-426a-a6e0-d601d8f47500)

closes #20 